### PR TITLE
Update awaySwitchAccessory.ts

### DIFF
--- a/src/awaySwitchAccessory.ts
+++ b/src/awaySwitchAccessory.ts
@@ -143,7 +143,13 @@ export class AwaySwitchAccessory {
 			const selectionMatch = this.platform.config.thermostatSerialNumbers || '';
 			const selectionType = selectionMatch ? 'thermostats' : 'registered';
 	
-			// Use setHold for all states (including home) to override built-in schedule
+			// Use setHold for all states (EXCLUDING home) as to _NOT_ override built-in schedule
+			
+			let theType = "setHold";
+	 		if (climateRef === "home") {
+	     			theType = "resumeProgram"
+	 		} 
+			
 			const setHoldBody = {
 				'selection': {
 					'selectionType': selectionType,
@@ -151,7 +157,7 @@ export class AwaySwitchAccessory {
 				},
 				'functions': [
 					{
-						'type': 'setHold',
+						'type': 'theType',
 						'params': {
 							'holdType': 'indefinite',
 							'holdClimateRef': climateRef,


### PR DESCRIPTION
I believe the idea to set "home" as an indefinite hold is flawed. This method means we'll only adhere to one heat/cool range all day, year round regardless of our sleep preferences. When we are home, we'll want the home, afternoon and sleep schedules to operate as we designed with in the Ecobee.

Having the "away" on indefinite makes sense and should stay as is.

This allows the behavior of "home" to resume schedule as an option in the configuration page for the plugin.